### PR TITLE
Only clear previous timestamp, cpu total and cpu idle at start and stop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl required version of autoconf
 AC_PREREQ([2.53])
 
 dnl TODO: fill in your package name and package version here
-AC_INIT([gst-perf],[0.2.2])
+AC_INIT([gst-perf],[0.2.3])
 
 dnl required versions of gstreamer and plugins-base
 GST_REQUIRED=1.0.0

--- a/plugins/gstperf.c
+++ b/plugins/gstperf.c
@@ -349,13 +349,8 @@ gst_perf_reset (GstPerf * perf)
 {
   g_return_if_fail (perf);
 
-  perf->prev_timestamp = GST_CLOCK_TIME_NONE;
-
   perf->frame_count = 0;
   perf->byte_count = G_GUINT64_CONSTANT (0);
-
-  perf->prev_cpu_total = 0;
-  perf->prev_cpu_idle = 0;
 }
 
 static void
@@ -370,6 +365,10 @@ gst_perf_clear (GstPerf * perf)
 
   perf->bps = 0.0;
   perf->byte_count_total = G_GUINT64_CONSTANT (0);
+
+  perf->prev_timestamp = GST_CLOCK_TIME_NONE;
+  perf->prev_cpu_total = 0;
+  perf->prev_cpu_idle = 0;
 }
 
 static gboolean


### PR DESCRIPTION
This avoids prev_timestamp, prev_cpu_total and prev_cpu_idle
to be clear each time the cpu load is calculated.