### PR TITLE
Add local-test shell script, which I use on the target

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# https://editorconfig.org
+
+root=true
+
+[*.{c,h,sh,sh.in}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ debian/tmp
 *.substvars
 *.changes
 *.buildinfo
+
+# test-locally.sh
+test-locally.sh
+/test-locally-install-dir

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ dnl set the plugindir where plugins should be installed (for plugins/Makefile.am
 if test "x${prefix}" = "x$HOME"; then
   plugindir="$HOME/.gstreamer-1.0/plugins"
 else
-  plugindir="\$(libdir)/gstreamer-1.0"
+  plugindir="${libdir}/gstreamer-1.0"
 fi
 AC_SUBST(plugindir)
 
@@ -87,4 +87,7 @@ GST_PLUGIN_LDFLAGS='-module -avoid-version -export-symbols-regex [_]*\(gst_\|Gst
 AC_SUBST(GST_PLUGIN_LDFLAGS)
 
 AC_CONFIG_FILES([Makefile plugins/Makefile])
+AC_CONFIG_FILES(
+    [test-locally.sh], [chmod +x test-locally.sh]
+)
 AC_OUTPUT

--- a/test-locally.sh.in
+++ b/test-locally.sh.in
@@ -1,0 +1,68 @@
+#!/bin/bash
+# @configure_input@
+#
+# test-locally.sh: open a shell for testing an installation of gst-perf
+# in a local directory.
+#
+# GST_DEBUG is set unless already set.  If GST_DEBUG_EXTRA is set, it will
+# be added to the end of GST_DEBUG, whether existing or default.
+#
+# Copyright (c) 2020 D3 Engineering, LLC
+# By Christopher White <cwhite@d3engineering.com>
+
+set -Eeuo pipefail
+
+# --- main ------------------------------------------------------------------
+
+main() {
+
+  # Collect variables
+  prefix="@prefix@"
+  exec_prefix="@exec_prefix@"
+  libdir="@libdir@"
+  bindir="@bindir@"
+  plugindir="@plugindir@"
+
+  # Install locally
+  destdir="$(realpath -m test-locally-install-dir)"
+  sync
+  rm -rf "$destdir"
+  V mkdir -p "$destdir"
+  V make -j4 install DESTDIR="$destdir"
+
+  # Set up environment
+  export G_MESSAGES_DEBUG=all
+  if [[ ! "${GST_DEBUG:-}" ]]; then
+      export GST_DEBUG='*:3,perf:6'
+  fi
+  export GST_DEBUG="$GST_DEBUG${GST_DEBUG_EXTRA:+,}${GST_DEBUG_EXTRA:-}"
+
+  export GST_PLUGIN_PATH="${destdir}@plugindir@:${GST_PLUGIN_PATH:-}"
+  export LD_LIBRARY_PATH="${destdir}@plugindir@:${LD_LIBRARY_PATH:-}"
+
+  # Open shell
+  if ! gst-inspect-1.0 perf &> /dev/null ; then
+    die "Could not find gst-perf plugin.  GST_PLUGIN_PATH=$GST_PLUGIN_PATH"
+  fi
+  V "${SHELL:-bash}"
+}
+
+# --- Helpers ---------------------------------------------------------------
+
+# Print the command, then run it
+V() {
+    echo '>>> ' "$@" 1>&2
+    "$@"
+}
+
+# Print an error message and exit
+function die() {
+    printf '%s ' 'Error:' "$@" 1>&2
+    echo 1>&2
+    echo "Aborting." 1>&2
+    exit 1
+} #die()
+
+# --- Run -------------------------------------------------------------------
+
+main "$@"


### PR DESCRIPTION
### Overview

**Problem:** I work on lots of different targets with different configurations.  Not all targets have `~/.gstreamer-1.0/plugins` in `GST_PLUGIN_PATH`.

**Solution** proposed by this PR: Add a shell script that:

1. installs gst-perf in a temporary directory; and 
2. opens a shell with that directory added to `GST_PLUGIN_PATH`.

I have been using this approach for several months on other projects and have had good success with it.

### Usage example

    $ ./autogen.sh && ./configure
    $ ./test-locally.sh
    # ... messages as it installs into ./test-locally-install-dir
    make[1]: Leaving directory '.../gst-perf'
    >>>  bash
    $ gst-launch-1.0 -v videotestsrc ! 'video/x-raw,framerate=30/1' ! perf ! fakesink sync=true
    # ... pipeline runs, using the local perf

### Other

I added an [EditorConfig](https://editorconfig.org) file that supported editors will use to apply the project's indentation settings, as I understand them.

Thank you for considering this PR!