### PR TITLE
Add .sh to ./autogen command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GStreamer element to measure framerate, bitrate and CPU usage
 
 On Debian-based systems:
 ```bash
-./autogen
+./autogen.sh
 ./configure --prefix /usr/ --libdir /usr/lib/x86_64-linux-gnu/
 make
 sudo make install


### PR DESCRIPTION
This branch fixes the README build instructions.