### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A GStreamer element to measure framerate, bitrate and CPU usage
 
 On Debian-based systems:
 ```bash
-./autogen
-./configure --prefix /usr/ --libdir /usr/lib/x86_64-linux-gnu/
+./autogen.sh
+./configure --prefix /usr/ --libdir /usr/lib/$(uname -m)-linux-gnu/
 make
 sudo make install
 ```


### PR DESCRIPTION
* The call to the autogen.sh script is missing the extension.
* The libdir argument in the configure script has been parameterized to contemplate other platforms.